### PR TITLE
Potential fix for code scanning alert no. 5: URL redirection from remote source

### DIFF
--- a/quotes/tests.py
+++ b/quotes/tests.py
@@ -141,6 +141,39 @@ class QuoteAddViewTest(TestCase):
         self.assertIn("form", response.context)
 
 
+class SafeRedirectTest(TestCase):
+    def setUp(self):
+        self.admin = User.objects.create_user(username="admin", password="testpass123")
+        self.quote = Quote.objects.create(content="<user> test", status=Quote.Status.APPROVED)
+
+    def test_malicious_referer_redirects_to_fallback(self):
+        response = self.client.post(
+            reverse("quote_vote_up", args=[self.quote.id]),
+            HTTP_REFERER="https://evil.com/steal-cookies",
+        )
+        self.assertRedirects(response, "/", fetch_redirect_response=False)
+
+    def test_safe_referer_is_preserved(self):
+        response = self.client.post(
+            reverse("quote_vote_up", args=[self.quote.id]),
+            HTTP_REFERER="http://testserver/quote/show",
+        )
+        self.assertRedirects(response, "http://testserver/quote/show", fetch_redirect_response=False)
+
+    def test_missing_referer_redirects_to_fallback(self):
+        response = self.client.post(reverse("quote_vote_up", args=[self.quote.id]))
+        self.assertRedirects(response, "/", fetch_redirect_response=False)
+
+    def test_malicious_referer_on_protected_view(self):
+        self.client.login(username="admin", password="testpass123")
+        quote = Quote.objects.create(content="<user> pending")
+        response = self.client.post(
+            reverse("quote_accept", args=[quote.id]),
+            HTTP_REFERER="https://evil.com/",
+        )
+        self.assertRedirects(response, "/", fetch_redirect_response=False)
+
+
 class QuoteDetailViewTest(TestCase):
     def test_view_single_quote(self):
         quote = Quote.objects.create(content="<a> test quote", status=Quote.Status.APPROVED)

--- a/quotes/views.py
+++ b/quotes/views.py
@@ -13,16 +13,17 @@ from .models import Quote
 
 
 def get_safe_redirect_url(request, fallback="/"):
-    """
-    Return a safe URL to redirect to, based on HTTP_REFERER.
-    Falls back to the given path if the referrer is not safe.
-    """
     referrer = request.META.get("HTTP_REFERER")
     if not referrer:
         return fallback
+    allowed_hosts = set(settings.ALLOWED_HOSTS)
+    if "*" in allowed_hosts:
+        # In dev mode ALLOWED_HOSTS=["*"], but url_has_allowed_host_and_scheme
+        # treats "*" as a literal hostname. Fall back to the request host.
+        allowed_hosts = {request.get_host()}
     if url_has_allowed_host_and_scheme(
         referrer,
-        allowed_hosts={request.get_host()},
+        allowed_hosts=allowed_hosts,
         require_https=request.is_secure(),
     ):
         return referrer

--- a/quotes/views.py
+++ b/quotes/views.py
@@ -6,9 +6,27 @@ from django.http import HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.http import require_POST
 from django.conf import settings
+from django.utils.http import url_has_allowed_host_and_scheme
 
 from .forms import AddQuoteForm
 from .models import Quote
+
+
+def get_safe_redirect_url(request, fallback="/"):
+    """
+    Return a safe URL to redirect to, based on HTTP_REFERER.
+    Falls back to the given path if the referrer is not safe.
+    """
+    referrer = request.META.get("HTTP_REFERER")
+    if not referrer:
+        return fallback
+    if url_has_allowed_host_and_scheme(
+        referrer,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
+        return referrer
+    return fallback
 
 
 def login_user(request):
@@ -117,7 +135,7 @@ def quote_accept(request, quote_id):
     quote.status = Quote.Status.APPROVED
     quote.acceptant = request.user
     quote.save()
-    return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/"))
+    return HttpResponseRedirect(get_safe_redirect_url(request))
 
 
 @login_required(login_url="/login/")
@@ -127,7 +145,7 @@ def quote_reject(request, quote_id):
     quote.status = Quote.Status.REJECTED
     quote.acceptant = request.user
     quote.save()
-    return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/"))
+    return HttpResponseRedirect(get_safe_redirect_url(request))
 
 
 @login_required(login_url="/login/")
@@ -135,7 +153,7 @@ def quote_reject(request, quote_id):
 def quote_delete(request, quote_id):
     quote = get_object_or_404(Quote, pk=quote_id)
     quote.delete()
-    return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/"))
+    return HttpResponseRedirect(get_safe_redirect_url(request))
 
 
 @require_POST
@@ -143,7 +161,7 @@ def quote_vote_up(request, quote_id):
     quote = get_object_or_404(Quote, pk=quote_id)
     quote.votes_up += 1
     quote.save()
-    return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/"))
+    return HttpResponseRedirect(get_safe_redirect_url(request))
 
 
 @require_POST
@@ -151,7 +169,7 @@ def quote_vote_down(request, quote_id):
     quote = get_object_or_404(Quote, pk=quote_id)
     quote.votes_down += 1
     quote.save()
-    return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/"))
+    return HttpResponseRedirect(get_safe_redirect_url(request))
 
 
 @require_POST


### PR DESCRIPTION
Potential fix for [https://github.com/KrzysztofHajdamowicz/bash.org-like/security/code-scanning/5](https://github.com/KrzysztofHajdamowicz/bash.org-like/security/code-scanning/5)

General approach: do not redirect to arbitrary URLs taken from user-controlled headers. Instead, either (a) validate the URL using Django’s `url_has_allowed_host_and_scheme` to ensure it’s safe and same-origin (or within a configured allowlist), or (b) only allow relative paths and/or fall back to a fixed safe URL.

Best minimal fix here: introduce a small helper in this file that safely derives a redirect target from `HTTP_REFERER`:

1. Read `HTTP_REFERER` from `request.META`.
2. Use `url_has_allowed_host_and_scheme` with `allowed_hosts` including the current host (`{request.get_host()}`) and `require_https` consistent with the current request.
3. If it passes, use it; otherwise, fall back to `'/'`.

Then replace the direct `HttpResponseRedirect(request.META.get("HTTP_REFERER", "/"))` calls in:

- `quote_accept` (line 120),
- `quote_reject` (line 130),
- `quote_delete` (line 138),
- `quote_vote_up` (line 146),
- `quote_vote_down` (line 154),

with `HttpResponseRedirect(get_safe_redirect_url(request))`.

Concretely:

- Add an import: `from django.utils.http import url_has_allowed_host_and_scheme`.
- Define `get_safe_redirect_url(request)` near the top of this file, before it is used, that implements the validation described above.
- Update each of the five functions to call this helper.

This keeps existing behavior (redirecting back to the referrer when it’s a safe same-site URL) while preventing redirects to attacker-controlled domains.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
